### PR TITLE
gluster-bugs: also request the comments when querying bugs

### DIFF
--- a/gluster-bugs.py
+++ b/gluster-bugs.py
@@ -97,6 +97,7 @@ def main():
     f.write('{"date": "%s", "bugs": [' % datetime.datetime.now())
 
     bzq = bz.build_query(product=LPPROJECT, status=BZSTATUS)
+    bzq['extra_fields'] = ['comments']
     bugs = bz.query(bzq)
     for task in bugs:
         try:


### PR DESCRIPTION
An update of `python-bugzilla` does not return the comments by default
anymore. We need them to parse for updates from Gerrit.

Fixes: #9
Signed-off-by: Niels de Vos <ndevos@redhat.com>