### PR TITLE
Finding bugs from BZ-comments fails because Gerrit now uses https

### DIFF
--- a/gluster-bugs.py
+++ b/gluster-bugs.py
@@ -33,7 +33,7 @@ BZURL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 BZSTATUS = ('NEW', 'ASSIGNED', 'POST', 'MODIFIED', 'ON_QA')
 BZPRIORITY = ('urgent', 'high', 'medium', 'unspecified', 'low')
 
-GERRIT_URL = "http://review.gluster.org"
+GERRIT_URL = "https://review.gluster.org"
 
 RE_LINK = re.compile(' %s/(\d+)' % GERRIT_URL)
 


### PR DESCRIPTION
The regular expression that goes through comments does not find any of
the recent changes that were posted. It seems the URL for the change has
moved to http and this makes the regex to fail.

By only checking for new changes (https URL), old changes are not found
any longer. This should not be much of a problem, as stale changes are
automatically abandoned and will get a new BZ-comment with new URL once
resurrected.

Signed-off-by: Niels de Vos <ndevos@redhat.com>